### PR TITLE
fix(fb_revealDeletedMessages): remove saved messages

### DIFF
--- a/scripts/fb_revealDeletedMessages.js
+++ b/scripts/fb_revealDeletedMessages.js
@@ -256,7 +256,7 @@ export default {
   },
 
   onClick: () => {
-    let len = window.ufs_rvdfm_all_msgs.length;
+    let len = Object.entries(window.ufs_rvdfm_all_msgs).length;
     if (!len) alert("Chức năng chưa lưu được tin nhắn nào.");
     else if (
       confirm(
@@ -267,7 +267,7 @@ export default {
           `   thì bạn sẽ ko biết được nội dung tin nhắn.`
       )
     ) {
-      window.ufs_rvdfm_all_msgs = [];
+      window.ufs_rvdfm_all_msgs = {};
       alert("Đã xóa " + len + " tin nhắn khỏi bộ nhớ.");
     }
   },


### PR DESCRIPTION
Chào bác. Em có thấy chức năng xoá các tin nhắn đã lưu của tính năng [FB Reveal Deleted Messages](https://github.com/HoangTran0410/useful-script/blob/fc8422930382e1d1447106886dc3d91143586246/scripts/fb_revealDeletedMessages.js#L258) không hoạt động. Nên em có sửa lại 1 chút. Mong bác xem qua và thử chạy ạ.
Cảm ơn bác vì extension vip :))